### PR TITLE
Rename from change-request to release-log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 
-Change Request
-==============
+Release Log
+===========
 
-Automate opening/closing of change requests for FT applications.
+Automate opening/closing of release log change requests for FT applications.
 
-[![Build status](https://img.shields.io/circleci/project/Financial-Times/change-request.svg)][ci]
+[![Build status](https://img.shields.io/circleci/project/Financial-Times/release-log.svg)][ci]
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)][license]
 
 ```sh
-change-request \
+release-log \
   --owner-email "you@ft.com" \
   --summary "Hello World" \
   --description "This is a description" \
@@ -31,39 +31,39 @@ Table Of Contents
 Requirements
 ------------
 
-Running the change request tool requires [Node.js] 4.x and [npm].
+Running the release log tool requires [Node.js] 4.x and [npm].
 
 
 Install
 -------
 
 ```sh
-npm install -g @financial-times/change-request
+npm install -g @financial-times/release-log
 ```
 
 Usage
 -----
 
 ```
-Usage: change-request [options]
+Usage: release-log [options]
 
   Options:
 
     -h, --help                            output usage information
     -V, --version                         output the version number
     -a, --api-key <key>                   the API key to use when accessing the CR API
-    -o, --owner-email <email>             the change request owner email address
-    -s, --summary <summary>               a short summary of the change
-    -d, --description <description>       a short description of the change
+    -o, --owner-email <email>             the release log owner email address
+    -s, --summary <summary>               a short summary of the release
+    -d, --description <description>       a short description of the release
     -f, --description-file <filename>     file to read description from, instead of --description
-    -r, --reason <reason>                 the reason for the change. Default: "Deployment"
-    -c, --open-category <category>        the category for opening the change request. One of "Major", "Minor", "Significant". Default: "Minor"
-    -C, --close-category <category>       the category for closing the change request. One of "Implemented", "Partially Implemented", "Rejected", "Rolled back", "Cancelled". Default: "Implemented"
-    -R, --risk-profile <risk-profile>     the risk profile for the change request. One of "Low", "Medium", "High". Default: "Low"
-    -e, --environment <environment>       the environment the change request applies to. One of "Production", "Test", "Development", "Disaster Recovery". Default: "Test"
+    -r, --reason <reason>                 the reason for the release. Default: "Deployment"
+    -c, --open-category <category>        the category for opening the release log. One of "Major", "Minor", "Significant". Default: "Minor"
+    -C, --close-category <category>       the category for closing the release log. One of "Implemented", "Partially Implemented", "Rejected", "Rolled back", "Cancelled". Default: "Implemented"
+    -R, --risk-profile <risk-profile>     the risk profile for the release log. One of "Low", "Medium", "High". Default: "Low"
+    -e, --environment <environment>       the environment the release log applies to. One of "Production", "Test", "Development", "Disaster Recovery". Default: "Test"
     -O, --outage                          whether there will be an outage. Default: false
-    -S, --service <service>               the service that the change request applies to
-    -n, --notify-channel <slack-channel>  the slack channel to notify of the change request
+    -S, --service <service>               the service that the release log applies to
+    -n, --notify-channel <slack-channel>  the slack channel to notify of the release
 ```
 
 
@@ -105,7 +105,7 @@ The Financial Times has published this software under the [MIT license][license]
 
 
 
-[ci]: https://circleci.com/gh/Financial-Times/change-request
+[ci]: https://circleci.com/gh/Financial-Times/release-log
 [license]: http://opensource.org/licenses/MIT
 [node.js]: https://nodejs.org/
 [npm]: https://www.npmjs.com/

--- a/bin/release-log.js
+++ b/bin/release-log.js
@@ -2,7 +2,7 @@
 'use strict';
 
 const chalk = require('chalk');
-const ChangeRequestClient = require('..');
+const ReleaseLogClient = require('..');
 const pkg = require('../package.json');
 const program = require('commander');
 const fs = require('fs');
@@ -18,15 +18,15 @@ program
 	)
 	.option(
 		'-o, --owner-email <email>',
-		'the change request owner email address'
+		'the release log owner email address'
 	)
 	.option(
 		'-s, --summary <summary>',
-		'a short summary of the change'
+		'a short summary of the release'
 	)
 	.option(
 		'-d, --description <description>',
-		'a short description of the change'
+		'a short description of the release'
 	)
 	.option(
 		'-f, --description-file <filename>',
@@ -34,23 +34,23 @@ program
 	)
 	.option(
 		'-r, --reason <reason>',
-		'the reason for the change. Default: "Deployment"'
+		'the reason for the release. Default: "Deployment"'
 	)
 	.option(
 		'-c, --open-category <category>',
-		'the category for opening the change request. One of "Major", "Minor", "Significant". Default: "Minor"'
+		'the category for opening the release log. One of "Major", "Minor", "Significant". Default: "Minor"'
 	)
 	.option(
 		'-C, --close-category <category>',
-		'the category for closing the change request. One of "Implemented", "Partially Implemented", "Rejected", "Rolled back", "Cancelled". Default: "Implemented"'
+		'the category for closing the release log. One of "Implemented", "Partially Implemented", "Rejected", "Rolled back", "Cancelled". Default: "Implemented"'
 	)
 	.option(
 		'-R, --risk-profile <risk-profile>',
-		'the risk profile for the change request. One of "Low", "Medium", "High". Default: "Low"'
+		'the risk profile for the release log. One of "Low", "Medium", "High". Default: "Low"'
 	)
 	.option(
 		'-e, --environment <environment>',
-		'the environment the change request applies to. One of "Production", "Test", "Development", "Disaster Recovery". Default: "Test"'
+		'the environment the release log applies to. One of "Production", "Test", "Development", "Disaster Recovery". Default: "Test"'
 	)
 	.option(
 		'-O, --outage',
@@ -58,16 +58,16 @@ program
 	)
 	.option(
 		'-S, --service <service>',
-		'the service that the change request applies to'
+		'the service that the release log applies to'
 	)
 	.option(
 		'-n, --notify-channel <slack-channel>',
-		'the slack channel to notify of the change request'
+		'the slack channel to notify of the release log'
 	)
 	.parse(process.argv);
 
 // Create an API client
-const crApi = new ChangeRequestClient({
+const releaseLogApi = new ReleaseLogClient({
 	apiKey: program.apiKey
 });
 
@@ -93,18 +93,18 @@ const closeData = {
 	notify: !!(program.notifyChannel)
 };
 
-// Create and close a change request
-console.log(chalk.cyan.underline('Creating a change request'));
-crApi.open(openData)
+// Create and close a release log
+console.log(chalk.cyan.underline('Creating a release log'));
+releaseLogApi.open(openData)
 	.then(response => {
 		const cr = response.body.changeRequests[0];
-		console.log(chalk.green(`Created change request "${cr.id}"`));
+		console.log(chalk.green(`Created release log "${cr.id}"`));
 		closeData.id = cr.id;
-		return crApi.close(closeData);
+		return releaseLogApi.close(closeData);
 	})
 	.then(response => {
 		const cr = response.body.changeRequests[0];
-		console.log(chalk.green(`Closed change request "${cr.id}"`));
+		console.log(chalk.green(`Closed release log "${cr.id}"`));
 	})
 	.catch(error => {
 		console.error(`${chalk.red(error.message)}

--- a/lib/release-log.js
+++ b/lib/release-log.js
@@ -4,7 +4,7 @@ const extend = require('node.extend');
 const pkg = require('../package.json');
 require('isomorphic-fetch');
 
-module.exports = class ChangeRequestClient {
+module.exports = class ReleaseLogClient {
 
 	constructor(options) {
 		options = extend(true, {
@@ -12,7 +12,7 @@ module.exports = class ChangeRequestClient {
 		}, options);
 		this.apiKey = options.apiKey;
 		this.host = options.host;
-		this.userAgent = `ft-change-request/${pkg.version}`;
+		this.userAgent = `ft-release-log/${pkg.version}`;
 	}
 
 	fetch(endpoint, options) {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "@financial-times/change-request",
+  "name": "@financial-times/release-log",
   "version": "0.0.0",
-  "description": "Automate opening/closing of change requests for FT applications",
+  "description": "Automate opening/closing of release log change requests for FT applications",
   "license": "MIT",
-  "main": "lib/change-request.js",
+  "main": "lib/release-log.js",
   "bin": {
-    "change-request": "bin/change-request.js"
+    "change-request": "bin/release-log.js",
+    "release-log": "bin/release-log.js"
   },
   "dependencies": {
     "chalk": "^1",

--- a/test/unit/lib/release-log.js
+++ b/test/unit/lib/release-log.js
@@ -5,25 +5,25 @@ const pkg = require('../../../package.json');
 const sinon = require('sinon');
 require('sinon-as-promised');
 
-describe('lib/change-request', () => {
-	let ChangeRequestClient;
+describe('lib/release-log', () => {
+	let ReleaseLogClient;
 
 	beforeEach(() => {
-		ChangeRequestClient = require('../../../lib/change-request');
+		ReleaseLogClient = require('../../../lib/release-log');
 		global.fetch = require('../mock/fetch');
 	});
 
 	it('exports a function', () => {
-		assert.isFunction(ChangeRequestClient);
+		assert.isFunction(ReleaseLogClient);
 	});
 
-	describe('new ChangeRequestClient(options)', () => {
+	describe('new ReleaseLogClient(options)', () => {
 		let instance;
 		let resolvedValue;
 		let caughtError;
 
 		beforeEach(() => {
-			instance = new ChangeRequestClient({
+			instance = new ReleaseLogClient({
 				apiKey: 'xxxxxx',
 				host: 'testhost'
 			});
@@ -44,7 +44,7 @@ describe('lib/change-request', () => {
 			});
 
 			it('has a `userAgent` property', () => {
-				assert.strictEqual(instance.userAgent, `ft-change-request/${pkg.version}`);
+				assert.strictEqual(instance.userAgent, `ft-release-log/${pkg.version}`);
 			});
 
 			it('has a `fetch` method', () => {
@@ -293,7 +293,7 @@ describe('lib/change-request', () => {
 		describe('when `options.host` is not set', () => {
 
 			beforeEach(() => {
-				instance = new ChangeRequestClient({
+				instance = new ReleaseLogClient({
 					apiKey: 'xxxxxx'
 				});
 			});


### PR DESCRIPTION
If I rename the repo just before merging then that should work. I can then deprecate the old package.