### PR TITLE
Add notice that the CR API has been decommissioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Release Log
 ===========
 
+🚨 The [Konstructor Change Request API](https://biz-ops.in.ft.com/System/koncrapi) that this package uses has been decommissioned. 🚨
+
 Automate opening/closing of release log change requests for FT applications.
 
 [![Build status](https://img.shields.io/circleci/project/Financial-Times/release-log.svg)][ci]


### PR DESCRIPTION
I found this package from a repo where we (the apps team) have it installed, but on investigating it seems that it's been decommissioned recently.